### PR TITLE
Fixed missing import of `arxiv.arxiv` when downloading PDFs

### DIFF
--- a/utils/download_arxiv_pdfs/download_arxiv_pdfs_from_doi_file_input/download_arxiv_pdfs.py
+++ b/utils/download_arxiv_pdfs/download_arxiv_pdfs_from_doi_file_input/download_arxiv_pdfs.py
@@ -1,6 +1,7 @@
 import os
 import csv
 import arxiv
+import arxiv.arxiv
 import argparse
 
 


### PR DESCRIPTION
This was causing issues when trying to reference for example `arxiv.arxiv.ArxivError`.